### PR TITLE
refactor(frontend): fix deprecation warnings

### DIFF
--- a/src/frontend/src/edit/Edit.tsx
+++ b/src/frontend/src/edit/Edit.tsx
@@ -1,5 +1,4 @@
 import ButtonGroup from '@atlaskit/button/button-group';
-import LoadingButton from '@atlaskit/button/loading-button';
 import Button from '@atlaskit/button/new';
 import Form, { FormFooter } from '@atlaskit/form';
 import { view } from '@forge/bridge';
@@ -47,13 +46,9 @@ export default function Edit() {
 
           <FormFooter align="start">
             <ButtonGroup label="Form submit options">
-              <LoadingButton
-                type="submit"
-                appearance="primary"
-                isLoading={submitting}
-              >
+              <Button type="submit" appearance="primary" isLoading={submitting}>
                 Save
-              </LoadingButton>
+              </Button>
 
               <Button onClick={handleCancel}>Cancel</Button>
             </ButtonGroup>

--- a/src/frontend/src/shared/AddButton.tsx
+++ b/src/frontend/src/shared/AddButton.tsx
@@ -1,5 +1,5 @@
 import { IconButton, type IconButtonProps } from '@atlaskit/button/new';
-import AddIcon from '@atlaskit/icon/glyph/add';
+import AddIcon from '@atlaskit/icon/core/add';
 
 export function AddButton(props: Omit<IconButtonProps, 'icon'>) {
   return <IconButton {...props} icon={AddIcon} />;

--- a/src/frontend/src/shared/DeleteButton.tsx
+++ b/src/frontend/src/shared/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import { IconButton, type IconButtonProps } from '@atlaskit/button/new';
-import CrossCircleIcon from '@atlaskit/icon/glyph/cross-circle';
+import CrossCircleIcon from '@atlaskit/icon/core/cross-circle';
 import { Box } from '@atlaskit/primitives';
 
 interface Props extends Omit<IconButtonProps, 'icon'> {


### PR DESCRIPTION
## What is the motivation for this pull request?

refactor(frontend): fix deprecation warnings

- `Edit.tsx`: Replaced deprecated `LoadingButton` with `Button` + `isLoading` prop
- `AddButton.tsx`: Changed `@atlaskit/icon/glyph/add` → `@atlaskit/icon/core/add`
- `DeleteButton.tsx`: Changed `@atlaskit/icon/glyph/cross-circle` → `@atlaskit/icon/core/cross-circle`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation